### PR TITLE
Fix incorrect prove_and_run guide

### DIFF
--- a/stwo_cairo_prover/crates/run_and_prove/src/main.rs
+++ b/stwo_cairo_prover/crates/run_and_prove/src/main.rs
@@ -14,10 +14,11 @@ use thiserror::Error;
 use tracing::{span, Level};
 
 /// Command line arguments for run_and_prove.
+/// (Currently only works for compiled Cairo 0 programs)
 /// Example command line (use absolute paths):
 ///     ```
-///     cargo run -r --bin run_and_prove -- --run_from_cairo_pie
-///     --proof_path path/to/proof --secure_run=true path/to/cairo/pie
+///     cargo run -r --bin run_and_prove --
+///     --proof_path path/to/proof --secure_run=true path/to/cairo/program
 ///     ```
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]


### PR DESCRIPTION
Support for Cairo PIEs were removed in [this PR](https://github.com/starkware-libs/stwo-cairo/pull/304) when adding wasm support. Fixing the run guide accordingly.